### PR TITLE
fix(lexicon): bulk auto-translate skips existing languages

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -5,7 +5,7 @@
 define('PKG_NAME', 'localizator');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-define('PKG_VERSION', '1.1.2');
+define('PKG_VERSION', '1.1.1');
 define('PKG_RELEASE', 'beta');
 define('PKG_AUTO_INSTALL', true);
 define('PKG_NAMESPACE_PATH', '{core_path}components/' . PKG_NAME_LOWER . '/');

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -5,7 +5,7 @@
 define('PKG_NAME', 'localizator');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-define('PKG_VERSION', '1.1.1');
+define('PKG_VERSION', '1.1.2');
 define('PKG_RELEASE', 'beta');
 define('PKG_AUTO_INSTALL', true);
 define('PKG_NAMESPACE_PATH', '{core_path}components/' . PKG_NAME_LOWER . '/');

--- a/core/components/localizator/docs/changelog.txt
+++ b/core/components/localizator/docs/changelog.txt
@@ -5,14 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.2-beta] - 2026-06-17
-
-### Fixed
-- Bulk lexicon auto-translate stopped after the first existing translation for a key (issue #9): `translate.class.php` uses `continue` instead of `break` so remaining languages are still processed when overwrite is disabled.
-
 ## [1.1.1-beta] - 2026-06-16
 
 ### Fixed
+- Bulk lexicon auto-translate stopped after the first existing translation for a key (issue #9): `translate.class.php` uses `continue` instead of `break` so remaining languages are still processed when overwrite is disabled.
 - MySQL 8 SQL syntax error in the localization fields grid when TVs are grouped by category: `rank` is a reserved word in MySQL 8 — `fields.class.php` now sorts by `` `rank` `` instead of `rank`, so category names render correctly instead of "Undefined".
 
 ## [1.1.0-beta] - 2026-02-04

--- a/core/components/localizator/docs/changelog.txt
+++ b/core/components/localizator/docs/changelog.txt
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2-beta] - 2026-06-17
+
+### Fixed
+- Bulk lexicon auto-translate stopped after the first existing translation for a key (issue #9): `translate.class.php` uses `continue` instead of `break` so remaining languages are still processed when overwrite is disabled.
+
 ## [1.1.1-beta] - 2026-06-16
 
 ### Fixed

--- a/core/components/localizator/processors/mgr/lexicon/translate.class.php
+++ b/core/components/localizator/processors/mgr/lexicon/translate.class.php
@@ -44,9 +44,9 @@ class localizatorLexiconTranslateProcessor extends modProcessor
 					'name' => $entry->name,
 				));
 
-				// если уже есть запись и указано не перезаписывать - прерываем цикл
-				if ($tmp->value && !$tranlate_all) {
-					break;
+				// если уже есть запись и указано не перезаписывать — пропускаем этот язык
+				if ($tmp && $tmp->get('value') && !$tranlate_all) {
+					continue;
 				}
 
 				if (!$tmp) {


### PR DESCRIPTION
Fix bulk lexicon auto-translate stopping after the first existing translation.

When **Automatic translation** runs with overwrite disabled (`localizator_translate_translated_fields`), the processor hit an existing entry for one language and used `break`, which exited the entire language loop for that lexicon key. Remaining languages were never translated or copied even though the action reported success.

The loop now uses `continue` to skip only the current language when a value already exists, and adds a null check before reading the entry value.

Release **1.1.2-beta**.

Fixes #9